### PR TITLE
transform async => generator in task wrapper

### DIFF
--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -1,5 +1,5 @@
 const { declare } = require('@babel/helper-plugin-utils');
-const { yieldExpression } = require('@babel/types');
+const { yieldExpression, functionExpression } = require('@babel/types');
 
 const TASK_DECORATORS = [
   'task',
@@ -85,8 +85,37 @@ const TransformAsyncMethodsIntoGeneratorMethods = {
       path.node.generator = true;
       path.traverse(TransformAwaitIntoYield);
     }
+  },
+  ClassProperty(path) {
+    if (hasTaskDecorator(path)) {
+      path.traverse(TaskProperty);
+    }
   }
 };
+
+const TaskProperty = {
+  CallExpression(path) {
+    if (isTaskDecorator(path)) {
+      path.traverse(TaskWrapper);
+    }
+  }
+};
+
+const TaskWrapper = {
+  FunctionExpression(path) {
+    if (path.node.async) {
+      path.node.async = false;
+      path.node.generator = true;
+      path.traverse(TransformAwaitIntoYield);
+    }
+  },
+  ArrowFunctionExpression(path) {
+    if (path.node.async) {
+      path.replaceWith(functionExpression(path.node.id, path.node.params, path.node.body, true));
+      path.traverse(TransformAwaitIntoYield);
+    }
+  }
+}
 
 const TransformAwaitIntoYield = {
   Function(path) {

--- a/tests/integration/async-task-functions-test.js
+++ b/tests/integration/async-task-functions-test.js
@@ -83,4 +83,132 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom('#value').hasText('Done!');
     assert.dom('#resolved').hasText('Wow!');
   });
+
+  test('it works when using task wrapper', async function(assert) {
+    let { promise, resolve } = defer();
+
+    this.owner.register('component:test', class extends Component {
+      resolved = null;
+
+      @task myTask = task(async function(arg) {
+        set(this, 'resolved', await promise);
+        return arg;
+      });
+
+      @computed('myTask.performCount')
+      get isWaiting() {
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning() {
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value() {
+        return this.myTask.last.value;
+      }
+    });
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+        {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
+
+  test('it works when using task wrapper with an arrow function', async function(assert) {
+    let { promise, resolve } = defer();
+
+    this.owner.register('component:test', class extends Component {
+      resolved = null;
+
+      @task myTask = task(async (arg) => {
+        set(this, 'resolved', await promise);
+        return arg;
+      });
+
+      @computed('myTask.performCount')
+      get isWaiting() {
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning() {
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value() {
+        return this.myTask.last.value;
+      }
+    });
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+        {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
 });


### PR DESCRIPTION
This adds the ability to transform async functions found inside the task wrapper implemented in https://github.com/machty/ember-concurrency-decorators/pull/76. It will work for both regular async functions and async arrow functions,

```ts
class MyClass {
  one = 1;

  @task
  myTask = task(async function() {
    await 1;
    return 2;
  });

  @task
  myTask = task(async () => {
    await this.one;
    return 2;
  });
}
```
 ||
 V
```ts
class MyClass {
  one = 1;

  @task
  myTask = task(function*() {
    yield 1;
    return 2;
  });

  @task
  myTask = task(function*() => {
    yield this.one;
    return 2;
  });
}
```