### PR TITLE
Transform taskFor

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,59 @@ import 'ember-concurrency-async';
 This augments ember-concurrency's type definitions to add support for async
 task functions. See [index.d.ts](index.d.ts).
 
+If you are using
+[ember-concurrency-ts](https://github.com/chancancode/ember-concurrency-ts),
+you may also need to add:
+
+```ts
+import 'ember-concurrency-ts/async';
+```
+
+### Usage with `taskFor` at assignment
+
+[ember-concurrency-ts](https://github.com/chancancode/ember-concurrency-ts)
+provides a `taskFor` utility function for casting task functions to the correct
+type. `taskFor` can be
+[used at assignment](https://github.com/chancancode/ember-concurrency-ts#alternate-usage-of-taskfor)
+and is compatible with `ember-concurrency-async`:
+
+```ts
+import { task } from 'ember-concurrency-decorators';
+import { taskFor } from 'ember-concurrency-ts';
+
+class Foo {
+  bar: Promise<void>;
+
+  @task
+  myTask = taskFor(async function(this: Foo) {
+    await this.bar;
+  });
+}
+```
+
+This also works with async arrow functions, eliminating the need to type
+`this`:
+
+```ts
+import { task } from 'ember-concurrency-decorators';
+import { taskFor } from 'ember-concurrency-ts';
+
+class Foo {
+  bar: Promise<void>;
+
+  @task
+  myTask = taskFor(async () => {
+    await this.bar;
+  });
+}
+```
+
+Note that async arrow functions are transformed to non-arrow generator
+functions (arrow generator functions
+[have been proposed](https://github.com/tc39/proposal-generator-arrow-functions)
+but no Babel plugin exists for them at this time). The `this` context *is*
+bound, however, by the `@task` decorator, so `this` inside the async function
+will still refer to the containing class at runtime.
 
 Contributing
 ------------------------------------------------------------------------------

--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -1,5 +1,5 @@
 const { declare } = require('@babel/helper-plugin-utils');
-const { yieldExpression } = require('@babel/types');
+const { yieldExpression, functionExpression } = require('@babel/types');
 
 const TASK_DECORATORS = [
   'task',
@@ -78,6 +78,20 @@ function hasTaskDecorator(path) {
   return false;
 }
 
+function isTaskForImport(resolved) {
+  return resolved.isNamed &&
+    resolved.name === 'taskFor' &&
+    resolved.source === 'ember-concurrency-ts';
+}
+
+function isTaskFor(path) {
+  let resolved;
+  if ((resolved = resolveImport(path))) {
+    return isTaskForImport(resolved);
+  }
+  return false;
+}
+
 const TransformAsyncMethodsIntoGeneratorMethods = {
   ClassMethod(path) {
     if (path.node.async && hasTaskDecorator(path)) {
@@ -85,8 +99,37 @@ const TransformAsyncMethodsIntoGeneratorMethods = {
       path.node.generator = true;
       path.traverse(TransformAwaitIntoYield);
     }
+  },
+  ClassProperty(path) {
+    if (hasTaskDecorator(path)) {
+      path.traverse(TaskProperty);
+    }
   }
 };
+
+const TaskProperty = {
+  CallExpression(path) {
+    if (isTaskFor(path.get('callee'))) {
+      path.traverse(TaskFor);
+    }
+  }
+};
+
+const TaskFor = {
+  FunctionExpression(path) {
+    if (path.node.async) {
+      path.node.async = false;
+      path.node.generator = true;
+      path.traverse(TransformAwaitIntoYield);
+    }
+  },
+  ArrowFunctionExpression(path) {
+    if (path.node.async) {
+      path.replaceWith(functionExpression(path.node.id, path.node.params, path.node.body, true));
+      path.traverse(TransformAwaitIntoYield);
+    }
+  }
+}
 
 const TransformAwaitIntoYield = {
   Function(path) {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-concurrency": "^1.2.1",
     "ember-concurrency-decorators": "^2.0.0",
+    "ember-concurrency-ts": "^0.2.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/tests/integration/async-task-functions-test.js
+++ b/tests/integration/async-task-functions-test.js
@@ -4,6 +4,7 @@ import { computed, set } from '@ember/object';
 import { click, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { task } from 'ember-concurrency-decorators';
+import { taskFor } from 'ember-concurrency-ts';
 import Component from '@glimmer/component';
 
 function defer() {
@@ -30,6 +31,134 @@ module('Integration | async-task-functions', function(hooks) {
         set(this, 'resolved', await promise);
         return arg;
       }
+
+      @computed('myTask.performCount')
+      get isWaiting() {
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning() {
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value() {
+        return this.myTask.last.value;
+      }
+    });
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+        {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
+
+  test('it works when using taskFor', async function(assert) {
+    let { promise, resolve } = defer();
+
+    this.owner.register('component:test', class extends Component {
+      resolved = null;
+
+      @task myTask = taskFor(async function(arg) {
+        set(this, 'resolved', await promise);
+        return arg;
+      });
+
+      @computed('myTask.performCount')
+      get isWaiting() {
+        return this.myTask.performCount === 0;
+      }
+
+      @computed('myTask.isRunning')
+      get isRunning() {
+        return this.myTask.isRunning;
+      }
+
+      @computed('myTask.last.value')
+      get value() {
+        return this.myTask.last.value;
+      }
+    });
+
+    this.owner.register('template:components/test', hbs`
+      {{#if this.isWaiting}}
+        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+      {{else if this.isRunning}}
+        Running!
+        {{else}}
+        Finished!
+        <span id="state">{{this.myTask.state}}</span>
+        <span id="value">{{this.value}}</span>
+        <span id="resolved">{{this.resolved}}</span>
+      {{/if}}
+    `);
+
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    resolve('Wow!');
+
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+  });
+
+  test('it works when using taskFor with an arrow function', async function(assert) {
+    let { promise, resolve } = defer();
+
+    this.owner.register('component:test', class extends Component {
+      resolved = null;
+
+      @task myTask = taskFor(async (arg) => {
+        set(this, 'resolved', await promise);
+        return arg;
+      });
 
       @computed('myTask.performCount')
       get isWaiting() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,6 +5113,14 @@ ember-concurrency-decorators@^2.0.0:
     ember-cli-htmlbars "^4.3.1"
     ember-cli-typescript "^3.1.4"
 
+ember-concurrency-ts@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-concurrency-ts/-/ember-concurrency-ts-0.2.0.tgz#0daa8d4334ec6dd78345d940615be9e45826b35a"
+  integrity sha512-cvdzoSzWWdtdGHOy4qisU0FI9F6Kz0/ZKXXszjW2fIE/dxeVuSKvnIppMnZO6K48L22v/Nq99Hj0OY4yCnz34A==
+  dependencies:
+    ember-cli-babel "^7.19.0"
+    ember-cli-htmlbars "^4.3.1"
+
 ember-concurrency@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.2.1.tgz#54fb234579638c5c43d4153a4e14567fe2b2e325"


### PR DESCRIPTION
This adds the ability to transform async functions found inside the `taskFor` from `ember-concurrency-ts`. It will work for both regular async functions and async arrow functions.

```ts
import { task } from 'ember-concurrency-decorators';
import { taskFor } from 'ember-concurrency-ts';

class MyClass {
  one = 1;

  @task
  myTask = taskFor(async function() {
    await 1;
    return 2;
  });

  @task
  myTask = taskFor(async () => {
    await this.one;
    return 2;
  });
}
```
 ||
 V
```ts
import { task } from 'ember-concurrency-decorators';
import { taskFor } from 'ember-concurrency-ts';

class MyClass {
  one = 1;

  @task
  myTask = taskFor(function*() {
    yield 1;
    return 2;
  });

  @task
  myTask = taskFor(function*() {
    yield this.one;
    return 2;
  });
}
```