### PR TITLE
Limit transform to one level

### DIFF
--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -1,5 +1,10 @@
 const { declare } = require('@babel/helper-plugin-utils');
-const { yieldExpression, functionExpression } = require('@babel/types');
+const {
+  yieldExpression,
+  functionExpression,
+  isFunctionExpression,
+  isArrowFunctionExpression,
+} = require('@babel/types');
 
 const TASK_DECORATORS = [
   'task',
@@ -110,26 +115,27 @@ const TransformAsyncMethodsIntoGeneratorMethods = {
 const TaskProperty = {
   CallExpression(path) {
     if (isTaskFor(path.get('callee'))) {
-      path.traverse(TaskFor);
+      const firstArg = path.get('arguments.0');
+      if (firstArg && firstArg.node.async) {
+        if (isFunctionExpression(firstArg)) {
+          firstArg.node.async = false;
+          firstArg.node.generator = true;
+        }
+        if (isArrowFunctionExpression(firstArg)) {
+          firstArg.replaceWith(
+            functionExpression(
+              firstArg.node.id,
+              firstArg.node.params,
+              firstArg.node.body,
+              true
+            )
+          );
+        }
+        firstArg.traverse(TransformAwaitIntoYield);
+      }
     }
   }
 };
-
-const TaskFor = {
-  FunctionExpression(path) {
-    if (path.node.async) {
-      path.node.async = false;
-      path.node.generator = true;
-      path.traverse(TransformAwaitIntoYield);
-    }
-  },
-  ArrowFunctionExpression(path) {
-    if (path.node.async) {
-      path.replaceWith(functionExpression(path.node.id, path.node.params, path.node.body, true));
-      path.traverse(TransformAwaitIntoYield);
-    }
-  }
-}
 
 const TransformAwaitIntoYield = {
   Function(path) {

--- a/tests/integration/async-task-functions-test.js
+++ b/tests/integration/async-task-functions-test.js
@@ -85,16 +85,17 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom('#resolved').hasText('Wow!');
   });
 
-  test('it works when using taskFor', async function(assert) {
+  test('it works when containing an async function', async function(assert) {
     let { promise, resolve } = defer();
 
     this.owner.register('component:test', class extends Component {
       resolved = null;
 
-      @task myTask = taskFor(async function(arg) {
-        set(this, 'resolved', await promise);
+      @task async myTask(arg) {
+        const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
+        set(this, 'resolved', result[0]);
         return arg;
-      });
+      }
 
       @computed('myTask.performCount')
       get isWaiting() {
@@ -137,7 +138,9 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom().containsText('Running!');
     assert.dom().doesNotContainText('Finished!');
 
-    resolve('Wow!');
+    let { promise: promise2, resolve: resolve2 } = defer();
+    resolve(promise2);
+    resolve2('Wow!');
 
     await settled();
 
@@ -149,16 +152,17 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom('#resolved').hasText('Wow!');
   });
 
-  test('it works when using taskFor with an arrow function', async function(assert) {
+  test('it works when containing an async arrow function', async function(assert) {
     let { promise, resolve } = defer();
 
     this.owner.register('component:test', class extends Component {
       resolved = null;
 
-      @task myTask = taskFor(async (arg) => {
-        set(this, 'resolved', await promise);
+      @task async myTask(arg) {
+        const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
+        set(this, 'resolved', result[0]);
         return arg;
-      });
+      }
 
       @computed('myTask.performCount')
       get isWaiting() {
@@ -201,7 +205,9 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom().containsText('Running!');
     assert.dom().doesNotContainText('Finished!');
 
-    resolve('Wow!');
+    let { promise: promise2, resolve: resolve2 } = defer();
+    resolve(promise2);
+    resolve2('Wow!');
 
     await settled();
 
@@ -211,5 +217,405 @@ module('Integration | async-task-functions', function(hooks) {
     assert.dom('#state').hasText('idle');
     assert.dom('#value').hasText('Done!');
     assert.dom('#resolved').hasText('Wow!');
+  });
+
+  module('taskFor', function() {
+    test('it works when using taskFor', async function(assert) {
+      let { promise, resolve } = defer();
+
+      this.owner.register('component:test', class extends Component {
+        resolved = null;
+
+        @task myTask = taskFor(async function(arg) {
+          set(this, 'resolved', await promise);
+          return arg;
+        });
+
+        @computed('myTask.performCount')
+        get isWaiting() {
+          return this.myTask.performCount === 0;
+        }
+
+        @computed('myTask.isRunning')
+        get isRunning() {
+          return this.myTask.isRunning;
+        }
+
+        @computed('myTask.last.value')
+        get value() {
+          return this.myTask.last.value;
+        }
+      });
+
+      this.owner.register('template:components/test', hbs`
+        {{#if this.isWaiting}}
+          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+        {{else if this.isRunning}}
+          Running!
+          {{else}}
+          Finished!
+          <span id="state">{{this.myTask.state}}</span>
+          <span id="value">{{this.value}}</span>
+          <span id="resolved">{{this.resolved}}</span>
+        {{/if}}
+      `);
+
+      await render(hbs`<Test />`);
+
+      assert.dom('button#start').hasText('Start!');
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      await click('button#start');
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().containsText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      resolve('Wow!');
+
+      await settled();
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().containsText('Finished!');
+      assert.dom('#state').hasText('idle');
+      assert.dom('#value').hasText('Done!');
+      assert.dom('#resolved').hasText('Wow!');
+    });
+
+    test('it works when using taskFor containing an async function', async function(assert) {
+      let { promise, resolve } = defer();
+
+      this.owner.register('component:test', class extends Component {
+        resolved = null;
+
+        @task myTask = taskFor(async function(arg) {
+          const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
+          set(this, 'resolved', result[0]);
+          return arg;
+        });
+
+        @computed('myTask.performCount')
+        get isWaiting() {
+          return this.myTask.performCount === 0;
+        }
+
+        @computed('myTask.isRunning')
+        get isRunning() {
+          return this.myTask.isRunning;
+        }
+
+        @computed('myTask.last.value')
+        get value() {
+          return this.myTask.last.value;
+        }
+      });
+
+      this.owner.register('template:components/test', hbs`
+        {{#if this.isWaiting}}
+          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+        {{else if this.isRunning}}
+          Running!
+          {{else}}
+          Finished!
+          <span id="state">{{this.myTask.state}}</span>
+          <span id="value">{{this.value}}</span>
+          <span id="resolved">{{this.resolved}}</span>
+        {{/if}}
+      `);
+
+      await render(hbs`<Test />`);
+
+      assert.dom('button#start').hasText('Start!');
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      await click('button#start');
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().containsText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      let { promise: promise2, resolve: resolve2 } = defer();
+      resolve(promise2);
+      resolve2('Wow!');
+
+      await settled();
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().containsText('Finished!');
+      assert.dom('#state').hasText('idle');
+      assert.dom('#value').hasText('Done!');
+      assert.dom('#resolved').hasText('Wow!');
+    });
+
+    test('it works when using taskFor containing an async arrow function', async function(assert) {
+      let { promise, resolve } = defer();
+
+      this.owner.register('component:test', class extends Component {
+        resolved = null;
+
+        @task myTask = taskFor(async function(arg) {
+          const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
+          set(this, 'resolved', result[0]);
+          return arg;
+        });
+
+        @computed('myTask.performCount')
+        get isWaiting() {
+          return this.myTask.performCount === 0;
+        }
+
+        @computed('myTask.isRunning')
+        get isRunning() {
+          return this.myTask.isRunning;
+        }
+
+        @computed('myTask.last.value')
+        get value() {
+          return this.myTask.last.value;
+        }
+      });
+
+      this.owner.register('template:components/test', hbs`
+        {{#if this.isWaiting}}
+          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+        {{else if this.isRunning}}
+          Running!
+          {{else}}
+          Finished!
+          <span id="state">{{this.myTask.state}}</span>
+          <span id="value">{{this.value}}</span>
+          <span id="resolved">{{this.resolved}}</span>
+        {{/if}}
+      `);
+
+      await render(hbs`<Test />`);
+
+      assert.dom('button#start').hasText('Start!');
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      await click('button#start');
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().containsText('Running!');
+      assert.dom().doesNotContainText('Finished!');
+
+      let { promise: promise2, resolve: resolve2 } = defer();
+      resolve(promise2);
+      resolve2('Wow!');
+
+      await settled();
+
+      assert.dom('button#start').doesNotExist();
+      assert.dom().doesNotContainText('Running!');
+      assert.dom().containsText('Finished!');
+      assert.dom('#state').hasText('idle');
+      assert.dom('#value').hasText('Done!');
+      assert.dom('#resolved').hasText('Wow!');
+    });
+
+    module('arrow function', function() {
+      test('it works when using taskFor with an arrow function', async function(assert) {
+        let { promise, resolve } = defer();
+
+        this.owner.register('component:test', class extends Component {
+          resolved = null;
+
+          @task myTask = taskFor(async (arg) => {
+            set(this, 'resolved', await promise);
+            return arg;
+          });
+
+          @computed('myTask.performCount')
+          get isWaiting() {
+            return this.myTask.performCount === 0;
+          }
+
+          @computed('myTask.isRunning')
+          get isRunning() {
+            return this.myTask.isRunning;
+          }
+
+          @computed('myTask.last.value')
+          get value() {
+            return this.myTask.last.value;
+          }
+        });
+
+        this.owner.register('template:components/test', hbs`
+          {{#if this.isWaiting}}
+            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+          {{else if this.isRunning}}
+            Running!
+            {{else}}
+            Finished!
+            <span id="state">{{this.myTask.state}}</span>
+            <span id="value">{{this.value}}</span>
+            <span id="resolved">{{this.resolved}}</span>
+          {{/if}}
+        `);
+
+        await render(hbs`<Test />`);
+
+        assert.dom('button#start').hasText('Start!');
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        await click('button#start');
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().containsText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        resolve('Wow!');
+
+        await settled();
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().containsText('Finished!');
+        assert.dom('#state').hasText('idle');
+        assert.dom('#value').hasText('Done!');
+        assert.dom('#resolved').hasText('Wow!');
+      });
+
+      test('it works when using taskFor with an arrow function containing an async function', async function(assert) {
+        let { promise, resolve } = defer();
+
+        this.owner.register('component:test', class extends Component {
+          resolved = null;
+
+          @task myTask = taskFor(async (arg) => {
+            const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
+            set(this, 'resolved', result[0]);
+            return arg;
+          });
+
+          @computed('myTask.performCount')
+          get isWaiting() {
+            return this.myTask.performCount === 0;
+          }
+
+          @computed('myTask.isRunning')
+          get isRunning() {
+            return this.myTask.isRunning;
+          }
+
+          @computed('myTask.last.value')
+          get value() {
+            return this.myTask.last.value;
+          }
+        });
+
+        this.owner.register('template:components/test', hbs`
+          {{#if this.isWaiting}}
+            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+          {{else if this.isRunning}}
+            Running!
+            {{else}}
+            Finished!
+            <span id="state">{{this.myTask.state}}</span>
+            <span id="value">{{this.value}}</span>
+            <span id="resolved">{{this.resolved}}</span>
+          {{/if}}
+        `);
+
+        await render(hbs`<Test />`);
+
+        assert.dom('button#start').hasText('Start!');
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        await click('button#start');
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().containsText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        let { promise: promise2, resolve: resolve2 } = defer();
+        resolve(promise2);
+        resolve2('Wow!');
+
+        await settled();
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().containsText('Finished!');
+        assert.dom('#state').hasText('idle');
+        assert.dom('#value').hasText('Done!');
+        assert.dom('#resolved').hasText('Wow!');
+      });
+
+      test('it works when using taskFor with an arrow function containing an async arrow function', async function(assert) {
+        let { promise, resolve } = defer();
+
+        this.owner.register('component:test', class extends Component {
+          resolved = null;
+
+          @task myTask = taskFor(async (arg) => {
+            const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
+            set(this, 'resolved', result[0]);
+            return arg;
+          });
+
+          @computed('myTask.performCount')
+          get isWaiting() {
+            return this.myTask.performCount === 0;
+          }
+
+          @computed('myTask.isRunning')
+          get isRunning() {
+            return this.myTask.isRunning;
+          }
+
+          @computed('myTask.last.value')
+          get value() {
+            return this.myTask.last.value;
+          }
+        });
+
+        this.owner.register('template:components/test', hbs`
+          {{#if this.isWaiting}}
+            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
+          {{else if this.isRunning}}
+            Running!
+            {{else}}
+            Finished!
+            <span id="state">{{this.myTask.state}}</span>
+            <span id="value">{{this.value}}</span>
+            <span id="resolved">{{this.resolved}}</span>
+          {{/if}}
+        `);
+
+        await render(hbs`<Test />`);
+
+        assert.dom('button#start').hasText('Start!');
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        await click('button#start');
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().containsText('Running!');
+        assert.dom().doesNotContainText('Finished!');
+
+        let { promise: promise2, resolve: resolve2 } = defer();
+        resolve(promise2);
+        resolve2('Wow!');
+
+        await settled();
+
+        assert.dom('button#start').doesNotExist();
+        assert.dom().doesNotContainText('Running!');
+        assert.dom().containsText('Finished!');
+        assert.dom('#state').hasText('idle');
+        assert.dom('#value').hasText('Done!');
+        assert.dom('#resolved').hasText('Wow!');
+      });
+    });
   });
 });

--- a/tests/integration/async-task-functions-test.js
+++ b/tests/integration/async-task-functions-test.js
@@ -18,36 +18,54 @@ function defer() {
   return { promise, resolve, reject };
 }
 
+class TestComponent extends Component {
+  resolved = null;
+
+  @computed('myTask.performCount')
+  get isWaiting() {
+    return this.myTask.performCount === 0;
+  }
+
+  @computed('myTask.isRunning')
+  get isRunning() {
+    return this.myTask.isRunning;
+  }
+
+  @computed('myTask.last.value')
+  get value() {
+    return this.myTask.last.value;
+  }
+}
+
+async function startTest(assert) {
+    await render(hbs`<Test />`);
+
+    assert.dom('button#start').hasText('Start!');
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+
+    await click('button#start');
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().containsText('Running!');
+    assert.dom().doesNotContainText('Finished!');
+}
+
+async function finishTest(assert) {
+    await settled();
+
+    assert.dom('button#start').doesNotExist();
+    assert.dom().doesNotContainText('Running!');
+    assert.dom().containsText('Finished!');
+    assert.dom('#state').hasText('idle');
+    assert.dom('#value').hasText('Done!');
+    assert.dom('#resolved').hasText('Wow!');
+}
+
 module('Integration | async-task-functions', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it works', async function(assert) {
-    let { promise, resolve } = defer();
-
-    this.owner.register('component:test', class extends Component {
-      resolved = null;
-
-      @task async myTask(arg) {
-        set(this, 'resolved', await promise);
-        return arg;
-      }
-
-      @computed('myTask.performCount')
-      get isWaiting() {
-        return this.myTask.performCount === 0;
-      }
-
-      @computed('myTask.isRunning')
-      get isRunning() {
-        return this.myTask.isRunning;
-      }
-
-      @computed('myTask.last.value')
-      get value() {
-        return this.myTask.last.value;
-      }
-    });
-
+  hooks.beforeEach(function() {
     this.owner.register('template:components/test', hbs`
       {{#if this.isWaiting}}
         <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
@@ -60,561 +78,179 @@ module('Integration | async-task-functions', function(hooks) {
         <span id="resolved">{{this.resolved}}</span>
       {{/if}}
     `);
+  });
 
-    await render(hbs`<Test />`);
+  test('it works', async function(assert) {
+    let { promise, resolve } = defer();
 
-    assert.dom('button#start').hasText('Start!');
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().doesNotContainText('Finished!');
+    this.owner.register('component:test', class extends TestComponent {
+      @task async myTask(arg) {
+        set(this, 'resolved', await promise);
+        return arg;
+      }
+    });
 
-    await click('button#start');
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().containsText('Running!');
-    assert.dom().doesNotContainText('Finished!');
+    await startTest(assert);
 
     resolve('Wow!');
 
-    await settled();
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().containsText('Finished!');
-    assert.dom('#state').hasText('idle');
-    assert.dom('#value').hasText('Done!');
-    assert.dom('#resolved').hasText('Wow!');
+    await finishTest(assert);
   });
 
   test('it works when containing an async function', async function(assert) {
     let { promise, resolve } = defer();
 
-    this.owner.register('component:test', class extends Component {
-      resolved = null;
-
+    this.owner.register('component:test', class extends TestComponent {
       @task async myTask(arg) {
         const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
         set(this, 'resolved', result[0]);
         return arg;
       }
-
-      @computed('myTask.performCount')
-      get isWaiting() {
-        return this.myTask.performCount === 0;
-      }
-
-      @computed('myTask.isRunning')
-      get isRunning() {
-        return this.myTask.isRunning;
-      }
-
-      @computed('myTask.last.value')
-      get value() {
-        return this.myTask.last.value;
-      }
     });
 
-    this.owner.register('template:components/test', hbs`
-      {{#if this.isWaiting}}
-        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-      {{else if this.isRunning}}
-        Running!
-        {{else}}
-        Finished!
-        <span id="state">{{this.myTask.state}}</span>
-        <span id="value">{{this.value}}</span>
-        <span id="resolved">{{this.resolved}}</span>
-      {{/if}}
-    `);
-
-    await render(hbs`<Test />`);
-
-    assert.dom('button#start').hasText('Start!');
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().doesNotContainText('Finished!');
-
-    await click('button#start');
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().containsText('Running!');
-    assert.dom().doesNotContainText('Finished!');
+    await startTest(assert);
 
     let { promise: promise2, resolve: resolve2 } = defer();
     resolve(promise2);
     resolve2('Wow!');
 
-    await settled();
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().containsText('Finished!');
-    assert.dom('#state').hasText('idle');
-    assert.dom('#value').hasText('Done!');
-    assert.dom('#resolved').hasText('Wow!');
+    await finishTest(assert);
   });
 
   test('it works when containing an async arrow function', async function(assert) {
     let { promise, resolve } = defer();
 
-    this.owner.register('component:test', class extends Component {
-      resolved = null;
-
+    this.owner.register('component:test', class extends TestComponent {
       @task async myTask(arg) {
         const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
         set(this, 'resolved', result[0]);
         return arg;
       }
-
-      @computed('myTask.performCount')
-      get isWaiting() {
-        return this.myTask.performCount === 0;
-      }
-
-      @computed('myTask.isRunning')
-      get isRunning() {
-        return this.myTask.isRunning;
-      }
-
-      @computed('myTask.last.value')
-      get value() {
-        return this.myTask.last.value;
-      }
     });
 
-    this.owner.register('template:components/test', hbs`
-      {{#if this.isWaiting}}
-        <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-      {{else if this.isRunning}}
-        Running!
-        {{else}}
-        Finished!
-        <span id="state">{{this.myTask.state}}</span>
-        <span id="value">{{this.value}}</span>
-        <span id="resolved">{{this.resolved}}</span>
-      {{/if}}
-    `);
-
-    await render(hbs`<Test />`);
-
-    assert.dom('button#start').hasText('Start!');
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().doesNotContainText('Finished!');
-
-    await click('button#start');
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().containsText('Running!');
-    assert.dom().doesNotContainText('Finished!');
+    await startTest(assert);
 
     let { promise: promise2, resolve: resolve2 } = defer();
     resolve(promise2);
     resolve2('Wow!');
 
-    await settled();
-
-    assert.dom('button#start').doesNotExist();
-    assert.dom().doesNotContainText('Running!');
-    assert.dom().containsText('Finished!');
-    assert.dom('#state').hasText('idle');
-    assert.dom('#value').hasText('Done!');
-    assert.dom('#resolved').hasText('Wow!');
+    await finishTest(assert);
   });
 
   module('taskFor', function() {
     test('it works when using taskFor', async function(assert) {
       let { promise, resolve } = defer();
 
-      this.owner.register('component:test', class extends Component {
-        resolved = null;
-
+      this.owner.register('component:test', class extends TestComponent {
         @task myTask = taskFor(async function(arg) {
           set(this, 'resolved', await promise);
           return arg;
         });
-
-        @computed('myTask.performCount')
-        get isWaiting() {
-          return this.myTask.performCount === 0;
-        }
-
-        @computed('myTask.isRunning')
-        get isRunning() {
-          return this.myTask.isRunning;
-        }
-
-        @computed('myTask.last.value')
-        get value() {
-          return this.myTask.last.value;
-        }
       });
 
-      this.owner.register('template:components/test', hbs`
-        {{#if this.isWaiting}}
-          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-        {{else if this.isRunning}}
-          Running!
-          {{else}}
-          Finished!
-          <span id="state">{{this.myTask.state}}</span>
-          <span id="value">{{this.value}}</span>
-          <span id="resolved">{{this.resolved}}</span>
-        {{/if}}
-      `);
-
-      await render(hbs`<Test />`);
-
-      assert.dom('button#start').hasText('Start!');
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().doesNotContainText('Finished!');
-
-      await click('button#start');
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().containsText('Running!');
-      assert.dom().doesNotContainText('Finished!');
+      await startTest(assert);
 
       resolve('Wow!');
 
-      await settled();
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().containsText('Finished!');
-      assert.dom('#state').hasText('idle');
-      assert.dom('#value').hasText('Done!');
-      assert.dom('#resolved').hasText('Wow!');
+      await finishTest(assert);
     });
 
     test('it works when using taskFor containing an async function', async function(assert) {
       let { promise, resolve } = defer();
 
-      this.owner.register('component:test', class extends Component {
-        resolved = null;
-
+      this.owner.register('component:test', class extends TestComponent {
         @task myTask = taskFor(async function(arg) {
           const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
           set(this, 'resolved', result[0]);
           return arg;
         });
-
-        @computed('myTask.performCount')
-        get isWaiting() {
-          return this.myTask.performCount === 0;
-        }
-
-        @computed('myTask.isRunning')
-        get isRunning() {
-          return this.myTask.isRunning;
-        }
-
-        @computed('myTask.last.value')
-        get value() {
-          return this.myTask.last.value;
-        }
       });
 
-      this.owner.register('template:components/test', hbs`
-        {{#if this.isWaiting}}
-          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-        {{else if this.isRunning}}
-          Running!
-          {{else}}
-          Finished!
-          <span id="state">{{this.myTask.state}}</span>
-          <span id="value">{{this.value}}</span>
-          <span id="resolved">{{this.resolved}}</span>
-        {{/if}}
-      `);
-
-      await render(hbs`<Test />`);
-
-      assert.dom('button#start').hasText('Start!');
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().doesNotContainText('Finished!');
-
-      await click('button#start');
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().containsText('Running!');
-      assert.dom().doesNotContainText('Finished!');
+      await startTest(assert);
 
       let { promise: promise2, resolve: resolve2 } = defer();
       resolve(promise2);
       resolve2('Wow!');
 
-      await settled();
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().containsText('Finished!');
-      assert.dom('#state').hasText('idle');
-      assert.dom('#value').hasText('Done!');
-      assert.dom('#resolved').hasText('Wow!');
+      await finishTest(assert);
     });
 
     test('it works when using taskFor containing an async arrow function', async function(assert) {
       let { promise, resolve } = defer();
 
-      this.owner.register('component:test', class extends Component {
-        resolved = null;
-
+      this.owner.register('component:test', class extends TestComponent {
         @task myTask = taskFor(async function(arg) {
           const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
           set(this, 'resolved', result[0]);
           return arg;
         });
-
-        @computed('myTask.performCount')
-        get isWaiting() {
-          return this.myTask.performCount === 0;
-        }
-
-        @computed('myTask.isRunning')
-        get isRunning() {
-          return this.myTask.isRunning;
-        }
-
-        @computed('myTask.last.value')
-        get value() {
-          return this.myTask.last.value;
-        }
       });
 
-      this.owner.register('template:components/test', hbs`
-        {{#if this.isWaiting}}
-          <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-        {{else if this.isRunning}}
-          Running!
-          {{else}}
-          Finished!
-          <span id="state">{{this.myTask.state}}</span>
-          <span id="value">{{this.value}}</span>
-          <span id="resolved">{{this.resolved}}</span>
-        {{/if}}
-      `);
-
-      await render(hbs`<Test />`);
-
-      assert.dom('button#start').hasText('Start!');
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().doesNotContainText('Finished!');
-
-      await click('button#start');
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().containsText('Running!');
-      assert.dom().doesNotContainText('Finished!');
+      await startTest(assert);
 
       let { promise: promise2, resolve: resolve2 } = defer();
       resolve(promise2);
       resolve2('Wow!');
 
-      await settled();
-
-      assert.dom('button#start').doesNotExist();
-      assert.dom().doesNotContainText('Running!');
-      assert.dom().containsText('Finished!');
-      assert.dom('#state').hasText('idle');
-      assert.dom('#value').hasText('Done!');
-      assert.dom('#resolved').hasText('Wow!');
+      await finishTest(assert);
     });
 
     module('arrow function', function() {
       test('it works when using taskFor with an arrow function', async function(assert) {
         let { promise, resolve } = defer();
 
-        this.owner.register('component:test', class extends Component {
-          resolved = null;
-
+        this.owner.register('component:test', class extends TestComponent {
           @task myTask = taskFor(async (arg) => {
             set(this, 'resolved', await promise);
             return arg;
           });
-
-          @computed('myTask.performCount')
-          get isWaiting() {
-            return this.myTask.performCount === 0;
-          }
-
-          @computed('myTask.isRunning')
-          get isRunning() {
-            return this.myTask.isRunning;
-          }
-
-          @computed('myTask.last.value')
-          get value() {
-            return this.myTask.last.value;
-          }
         });
 
-        this.owner.register('template:components/test', hbs`
-          {{#if this.isWaiting}}
-            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-          {{else if this.isRunning}}
-            Running!
-            {{else}}
-            Finished!
-            <span id="state">{{this.myTask.state}}</span>
-            <span id="value">{{this.value}}</span>
-            <span id="resolved">{{this.resolved}}</span>
-          {{/if}}
-        `);
-
-        await render(hbs`<Test />`);
-
-        assert.dom('button#start').hasText('Start!');
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().doesNotContainText('Finished!');
-
-        await click('button#start');
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().containsText('Running!');
-        assert.dom().doesNotContainText('Finished!');
+        await startTest(assert);
 
         resolve('Wow!');
 
-        await settled();
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().containsText('Finished!');
-        assert.dom('#state').hasText('idle');
-        assert.dom('#value').hasText('Done!');
-        assert.dom('#resolved').hasText('Wow!');
+        await finishTest(assert);
       });
 
       test('it works when using taskFor with an arrow function containing an async function', async function(assert) {
         let { promise, resolve } = defer();
 
-        this.owner.register('component:test', class extends Component {
-          resolved = null;
-
+        this.owner.register('component:test', class extends TestComponent {
           @task myTask = taskFor(async (arg) => {
             const result = await Promise.all([promise].map(async function(p) { const r = await p; return r }));
             set(this, 'resolved', result[0]);
             return arg;
           });
-
-          @computed('myTask.performCount')
-          get isWaiting() {
-            return this.myTask.performCount === 0;
-          }
-
-          @computed('myTask.isRunning')
-          get isRunning() {
-            return this.myTask.isRunning;
-          }
-
-          @computed('myTask.last.value')
-          get value() {
-            return this.myTask.last.value;
-          }
         });
 
-        this.owner.register('template:components/test', hbs`
-          {{#if this.isWaiting}}
-            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-          {{else if this.isRunning}}
-            Running!
-            {{else}}
-            Finished!
-            <span id="state">{{this.myTask.state}}</span>
-            <span id="value">{{this.value}}</span>
-            <span id="resolved">{{this.resolved}}</span>
-          {{/if}}
-        `);
-
-        await render(hbs`<Test />`);
-
-        assert.dom('button#start').hasText('Start!');
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().doesNotContainText('Finished!');
-
-        await click('button#start');
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().containsText('Running!');
-        assert.dom().doesNotContainText('Finished!');
+        await startTest(assert);
 
         let { promise: promise2, resolve: resolve2 } = defer();
         resolve(promise2);
         resolve2('Wow!');
 
-        await settled();
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().containsText('Finished!');
-        assert.dom('#state').hasText('idle');
-        assert.dom('#value').hasText('Done!');
-        assert.dom('#resolved').hasText('Wow!');
+        await finishTest(assert);
       });
 
       test('it works when using taskFor with an arrow function containing an async arrow function', async function(assert) {
         let { promise, resolve } = defer();
 
-        this.owner.register('component:test', class extends Component {
-          resolved = null;
-
+        this.owner.register('component:test', class extends TestComponent {
           @task myTask = taskFor(async (arg) => {
             const result = await Promise.all([promise].map(async (p) => { const r = await p; return r }));
             set(this, 'resolved', result[0]);
             return arg;
           });
-
-          @computed('myTask.performCount')
-          get isWaiting() {
-            return this.myTask.performCount === 0;
-          }
-
-          @computed('myTask.isRunning')
-          get isRunning() {
-            return this.myTask.isRunning;
-          }
-
-          @computed('myTask.last.value')
-          get value() {
-            return this.myTask.last.value;
-          }
         });
 
-        this.owner.register('template:components/test', hbs`
-          {{#if this.isWaiting}}
-            <button id="start" {{on "click" (perform this.myTask "Done!")}}>Start!</button>
-          {{else if this.isRunning}}
-            Running!
-            {{else}}
-            Finished!
-            <span id="state">{{this.myTask.state}}</span>
-            <span id="value">{{this.value}}</span>
-            <span id="resolved">{{this.resolved}}</span>
-          {{/if}}
-        `);
-
-        await render(hbs`<Test />`);
-
-        assert.dom('button#start').hasText('Start!');
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().doesNotContainText('Finished!');
-
-        await click('button#start');
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().containsText('Running!');
-        assert.dom().doesNotContainText('Finished!');
+        await startTest(assert);
 
         let { promise: promise2, resolve: resolve2 } = defer();
         resolve(promise2);
         resolve2('Wow!');
 
-        await settled();
-
-        assert.dom('button#start').doesNotExist();
-        assert.dom().doesNotContainText('Running!');
-        assert.dom().containsText('Finished!');
-        assert.dom('#state').hasText('idle');
-        assert.dom('#value').hasText('Done!');
-        assert.dom('#resolved').hasText('Wow!');
+        await finishTest(assert);
       });
     });
   });


### PR DESCRIPTION
Fixes #9

This changes the transform to only operate directly on the first argument of `taskFor()` rather than any async function found within `taskFor()`. This solves the issue with nested async functions being erroneously transformed into generators as well as optimizes the transform a bit since it no longer traverses the whole tree under `taskFor()` looking for async functions (it still has to traverse looking for `await`, but at least this is only one traversal per task).

I added tests for regular and arrow async functions being nested under regular and arrow async functions passed to `taskFor()`. I also added tests for regular and arrow async functions nested inside a task declared as a generator method (without `taskFor()`) even though this was not breaking (for completeness). Since I added a number of tests, I organized them into sub-modules. There was also a lot of redundancy in the tests, so I factored it out making it easier to see what differs between tests.