### PR TITLE
Engines fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/helper-plugin-utils": "^7.10.1",
     "@babel/types": "^7.10.2",
     "ember-cli-babel": "^7.19.0",
-    "ember-cli-babel-plugin-helpers": "^1.1.0",
+    "ember-cli-babel-plugin-helpers": "^1.1.1",
     "ember-cli-htmlbars": "^4.3.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,10 +4741,10 @@ ember-auto-import@^1.5.3:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
-  integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
+ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
+  integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
 ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
   version "6.18.0"


### PR DESCRIPTION
Fixes #1 

https://github.com/dfreeman/ember-cli-babel-plugin-helpers/pull/13 patches `ember-cli-babel-plugin-helpers` to allow `hasPlugin` to work when providing a full path to a plugin and was released as `ember-cli-babel-plugin-helpers@1.1.1`.

This bumps `ember-cli-babel-plugin-helpers` to `^1.1.1`.