### PR TITLE
Move ember-cli-htmlbars to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "@babel/helper-plugin-utils": "^7.10.1",
     "@babel/types": "^7.10.2",
     "ember-cli-babel": "^7.19.0",
-    "ember-cli-babel-plugin-helpers": "^1.1.1",
-    "ember-cli-htmlbars": "^4.3.1"
+    "ember-cli-babel-plugin-helpers": "^1.1.1"
   },
   "peerDependencies": {
     "ember-concurrency": "^2.0.0-rc.1"
@@ -49,6 +48,7 @@
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.18.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",


### PR DESCRIPTION
As this addon does not need to compile any own templates, and ember-cli-htmlbars is only imported from in tests, I think it should be safe to move it to `devDependencies`.

*Helps a bit with mitigating dependency hell and lock file maintenance*